### PR TITLE
Fixed issue when finding ei include path with multiple results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-EILOCN:=$(shell find /usr/local/lib/erlang /usr/lib/erlang -name ei.h -printf '%h' 2> /dev/null | head -1)
+EILOCN:=$(shell find /usr/local/lib/erlang /usr/lib/erlang -name ei.h -printf '%h\n' 2> /dev/null | head -1)
 CFLAGS=-Wall -std=c99 -I$(EILOCN)
 
 all: portutil.o


### PR DESCRIPTION
The issue was hapening when multiple paths were returned: they were not separated by a newline. The 'head' command was unable to properly get the first returned path and was instead returning all paths concatenated together. This made the erl_interface.h file unavailable and created a build error.

Thanks!
Francis
