### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC=gcc
-EILOCN:=$(shell find /usr/local/lib/erlang /usr/lib/erlang -name ei.h -printf '%h\n' 2> /dev/null | head -1)
+EIFILE:=$(shell find /usr/local/lib/erlang /usr/lib/erlang -name ei.h 2> /dev/null | head -1)
+EILOCN:=$(shell dirname $(EIFILE) ) 
 CFLAGS=-Wall -std=c99 -I$(EILOCN)
 
 all: portutil.o

--- a/portutil.c
+++ b/portutil.c
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 #include <erl_interface.h>
 #include <ei.h>


### PR DESCRIPTION
Two minor fixes:

Makefile:
Allow this to be compiled on BSD because the find parameter of '%h' is a GNU'ism only.  This new patch finds the file and uses the more widely

malloc.h included header:
I think that malloc.h shouldn't be used anymore.  Most modern Linux (and OSX) distributions don't seem to have it.  If you have a really old Linux distro that you need to support you may wish to use enable this header. 

You can accept/deny both of these based on your use case.    Thankyou for your time.
