### PR TITLE
Locate ei

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-EILOCN:=$(shell find /usr/local/lib/erlang /usr/lib/erlang -name ei.h -printf '%h\n' 2> /dev/null | head -1)
+EILOCN:=$(shell erl -hidden -eval 'io:format("~p", [code:root_dir()]).' -s erlang halt | grep '1>' | sed 's/"\(.*\)"1>/\1\/usr\/include/')
 CFLAGS=-Wall -std=c99 -I$(EILOCN)
 
 all: portutil.o

--- a/portutil.c
+++ b/portutil.c
@@ -21,7 +21,10 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 
 #include <erl_interface.h>
 #include <ei.h>


### PR DESCRIPTION
Better location of where `ei.h` is.
Only include `malloc.h` on platforms that has it - using `HAVE_MALLOC_H` to detect.